### PR TITLE
fix: add vue index.html file in host app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,6 @@ out
 
 # Gatsby files
 .cache/
-public
 
 # Storybook build outputs
 .out

--- a/apps/host/public/index.html
+++ b/apps/host/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="/favicon.ico">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Host App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="../src/index.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
App doesn't work without this. wasn't checked in cause of the `public/` directory being ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public HTML entry point with a basic scaffold and root container to bootstrap the app for simpler static hosting and local loading.

* **Chores**
  * Updated ignore settings so public assets are tracked in version control, enabling the new entry point and related static files to be committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->